### PR TITLE
[ Feature ] Remove personal email from contact page

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,12 +1,10 @@
 import { ContactForm } from "./components/ContactForm";
-import { EmailLink } from "@/components/social/EmailLink";
 import { LinkedInLink } from "@/components/social/LinkedInLink";
 import { GitHubLink } from "@/components/social/GitHubLink";
 
 export default function ContactPage() {
   const linkedInProfile = "rodrigo-lajous";
   const githubUsername = "rlajous";
-  const email = "rodrigolajous@gmail.com";
 
   return (
     <div className="flex flex-col items-center justify-center row-span-8 lg:row-span-11 w-full px-4 py-4 lg:py-6">
@@ -23,7 +21,6 @@ export default function ContactPage() {
         <div className="flex flex-col items-center space-y-4">
           <LinkedInLink profile={linkedInProfile} showText={true} />
           <GitHubLink username={githubUsername} showText={true} />
-          <EmailLink email={email} showText={true} />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary

Removes hardcoded personal email from contact page for privacy protection.

## Changes

- Removed hardcoded email address from `app/contact/page.tsx`
- Removed `EmailLink` component from contact page
- Removed unused `EmailLink` import
- Contact page now displays only LinkedIn and GitHub links

## Why

Personal email was publicly exposed in the codebase, which could lead to spam or privacy concerns. Users can still reach out through the contact form, which uses the private `RECIPIENT_EMAIL` environment variable.

## Testing

- Tested locally with `npm run dev`
- Verified contact page displays correctly without email link
- Confirmed contact form still works for communication
- Tested responsive design (mobile/tablet/desktop)
- Verified in both light and dark modes

## Breaking Changes

None - backwards compatible. Contact form remains functional for user communication.

## Deployment

This will auto-deploy to Vercel upon merge to main:
- **Preview**: Available in PR checks below
- **Production**: navarrolajous.com
- **Secondary**: www.navarrolajous.com

## Files Changed

- `app/contact/page.tsx`

---

**Checklist:**

- [x] Code follows Next.js best practices
- [x] Responsive design tested (mobile/tablet/desktop)
- [x] Dark mode verified
- [x] Build succeeds locally
- [x] TypeScript types correct
- [x] SEO metadata updated if needed
- [x] Accessibility verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed email contact option from the Contact page. Users can no longer submit contact requests via email through this page. All other contact methods and sections remain available and unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->