### PR TITLE
[ Content ] Update DeFi Security Summit talk video link

### DIFF
--- a/services/talks.ts
+++ b/services/talks.ts
@@ -64,7 +64,7 @@ export const talks: Talk[] = [
     ],
     links: {
       slides: "/assets/talks/dss-ai-onchain-trust-safety.pdf",
-      video: "https://www.youtube.com/watch?v=dkVCX-inxFI",
+      video: "https://www.youtube.com/watch?v=9wq2BhjKAFI",
     },
     banner: "/talks/dss-banner.jpeg",
   },


### PR DESCRIPTION
## Summary

Update YouTube video link for DeFi Security Summit 2025 talk to the correct URL.

## Changes

- Updated video URL in `services/talks.ts` from old link to new correct YouTube URL

## Why

The previous video link was incorrect. This updates it to point to the actual DSS 2025 talk recording.

## Testing

- Verified the new YouTube link is correct and accessible
- Build succeeds locally

## Breaking Changes

None - backwards compatible

## Deployment

This will auto-deploy to Vercel upon merge to main:
- **Preview**: Available in PR checks below
- **Production**: navarrolajous.com
- **Secondary**: www.navarrolajous.com

## Files Changed

- `services/talks.ts`

---

**Checklist:**

- [x] Code follows Next.js best practices
- [x] Build succeeds locally
- [x] TypeScript types correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated video link for a talk entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->