### PR TITLE
[ SEO ] Fix canonical URLs and block API route from crawlers (#32)

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,16 @@
+import { Metadata } from "next";
 import { ContactForm } from "./components/ContactForm";
 import { LinkedInLink } from "@/components/social/LinkedInLink";
 import { GitHubLink } from "@/components/social/GitHubLink";
+
+export const metadata: Metadata = {
+  title: "Contact | Rodrigo Manuel Navarro Lajous",
+  description:
+    "Get in touch with Rodrigo Manuel Navarro Lajous for project inquiries and collaborations.",
+  alternates: {
+    canonical: "/contact",
+  },
+};
 
 export default function ContactPage() {
   const linkedInProfile = "rodrigo-lajous";

--- a/app/education/[slug]/page.tsx
+++ b/app/education/[slug]/page.tsx
@@ -50,6 +50,9 @@ export async function generateMetadata({
       "education",
       "academic",
     ],
+    alternates: {
+      canonical: `/education/${slug}`,
+    },
     openGraph: {
       title: `${edu.degree} at ${edu.institution}`,
       description: edu.specialization

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   title: "Education | Rodrigo Manuel Navarro Lajous",
   description:
     "Academic background of Rodrigo Manuel Navarro Lajous, including his master's in software engineering and bachelor's degree.",
+  alternates: {
+    canonical: "/education",
+  },
 };
 
 export default function EducationPage() {

--- a/app/experience/[slug]/page.tsx
+++ b/app/experience/[slug]/page.tsx
@@ -42,6 +42,9 @@ export async function generateMetadata({
       experience.position,
       experience.type === "job" ? "employment" : "startup",
     ],
+    alternates: {
+      canonical: `/experience/${slug}`,
+    },
     openGraph: {
       title: `${experience.position} at ${experience.company}`,
       description: experience.responsibilities.join(" "),

--- a/app/experience/layout.tsx
+++ b/app/experience/layout.tsx
@@ -4,6 +4,9 @@ export const metadata: Metadata = {
   title: "Experience | Rodrigo Manuel Navarro Lajous",
   description:
     "Professional journey of Rodrigo Manuel Navarro Lajous, showcasing his work experience and roles.",
+  alternates: {
+    canonical: "/experience",
+  },
 };
 
 export default function ExperienceLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,9 +36,6 @@ export const metadata: Metadata = {
     follow: true,
   },
   metadataBase: new URL(SITE_URL),
-  alternates: {
-    canonical: "/",
-  },
   openGraph: {
     title: "Rodrigo Manuel Navarro Lajous | Software Engineer & Digital Nomad",
     description:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,15 @@
+import { Metadata } from "next";
 import { GitHubLink } from "@/components/social/GitHubLink";
 import { LinkedInLink } from "@/components/social/LinkedInLink";
 import { TwitterLink } from "@/components/social/TwitterLink";
 import { Button } from "@/components/ui/button";
 import { Download, Newspaper } from "lucide-react";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/",
+  },
+};
 
 export default function Home() {
   const githubUsername = "rlajous";

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -38,6 +38,9 @@ export async function generateMetadata({
     title: `${project.name} - ${project.company} | Rodrigo Manuel Navarro Lajous`,
     description: project.detailedDescription || project.description,
     keywords: [...project.technologies, project.name, project.company, project.type],
+    alternates: {
+      canonical: `/projects/${slug}`,
+    },
     openGraph: {
       title: `${project.name} - ${project.company}`,
       description: project.detailedDescription || project.description,

--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -4,6 +4,9 @@ export const metadata: Metadata = {
   title: "Projects | Rodrigo Manuel Navarro Lajous",
   description:
     "Portfolio of projects by Rodrigo Manuel Navarro Lajous, including freelance, hobby, and open source work.",
+  alternates: {
+    canonical: "/projects",
+  },
 };
 
 export default function ProjectsLayout({

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,6 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
+      disallow: "/api/",
     },
     sitemap: `${SITE_URL}/sitemap.xml`,
   };

--- a/app/talks/[slug]/page.tsx
+++ b/app/talks/[slug]/page.tsx
@@ -36,6 +36,9 @@ export async function generateMetadata({ params }: TalkPageProps): Promise<Metad
     title: `${talk.title} | Rodrigo Manuel Navarro Lajous`,
     description: talk.description,
     keywords: [...talk.topics, talk.event, "conference talk", "presentation"],
+    alternates: {
+      canonical: `/talks/${slug}`,
+    },
     openGraph: {
       title: talk.title,
       description: talk.description,

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   title: "Talks | Rodrigo Manuel Navarro Lajous",
   description:
     "Speaking engagements and conference talks by Rodrigo Manuel Navarro Lajous, including presentations at Devconnect and other blockchain conferences.",
+  alternates: {
+    canonical: "/talks",
+  },
 };
 
 export default function TalksPage() {


### PR DESCRIPTION
## Summary

Fix Google Search Console coverage issues caused by a global canonical URL misconfiguration. The root layout was setting `canonical: "/"` for **all pages**, making Google treat every page as a duplicate of the homepage. This PR adds correct per-page canonical URLs and blocks the API route from crawlers.

## Changes

- Removed global `alternates: { canonical: "/" }` from root layout that was inherited by all pages
- Added unique canonical URLs to all 6 static pages (home, experience, projects, education, talks, contact)
- Added dynamic canonical URLs to all 4 `generateMetadata` functions (experience/projects/education/talks detail pages)
- Added `disallow: "/api/"` to `robots.ts` to prevent crawlers from hitting the POST-only contact API (was returning 403)
- Added missing metadata (title, description) to the contact page

## Why

Google Search Console reported **16 not-indexed pages** with these critical issues:
- **6 pages** flagged as "Duplicated: user hasn't indicated canonical version" — caused by every page claiming `/` as canonical
- **1 page** blocked with 403 — the `/api/contact` route only accepts POST requests
- The remaining issues (redirects, crawled-not-indexed) are expected behavior (www→non-www, llms.txt files)

## Testing

- Build succeeds with `npm run build` (33/33 static pages generated)
- Verified canonical tags in built HTML — each page now has its own unique canonical URL:
  - `/` → `https://navarrolajous.com`
  - `/experience` → `https://navarrolajous.com/experience`
  - `/experience/webacy` → `https://navarrolajous.com/experience/webacy`
  - (same pattern for all other pages)
- Verified in both light and dark modes
- Responsive design unaffected (metadata-only changes)

## Breaking Changes

None — backwards compatible.

## Deployment

This will auto-deploy to Vercel upon merge to main:
- **Preview**: Available in PR checks below
- **Production**: navarrolajous.com
- **Secondary**: www.navarrolajous.com

## Post-Deploy

After merging, resubmit the sitemap in Google Search Console and request re-validation of the "Duplicated" issues.

## Files Changed

- `app/layout.tsx` — removed global canonical
- `app/page.tsx` — added homepage metadata with canonical
- `app/experience/layout.tsx` — added canonical
- `app/experience/[slug]/page.tsx` — added canonical to generateMetadata
- `app/projects/layout.tsx` — added canonical
- `app/projects/[slug]/page.tsx` — added canonical to generateMetadata
- `app/education/page.tsx` — added canonical
- `app/education/[slug]/page.tsx` — added canonical to generateMetadata
- `app/talks/page.tsx` — added canonical
- `app/talks/[slug]/page.tsx` — added canonical to generateMetadata
- `app/contact/page.tsx` — added metadata with canonical
- `app/robots.ts` — added disallow `/api/`

---

**Checklist:**

- [x] Code follows Next.js best practices
- [x] Responsive design tested (mobile/tablet/desktop)
- [x] Dark mode verified
- [x] Build succeeds locally
- [x] TypeScript types correct
- [x] SEO metadata updated if needed
- [x] Accessibility verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Configuration**
  * Canonical URL metadata is now configured across all primary website pages, including the homepage, contact, education, experience, projects, and talks sections.
  * Search engine crawlers have been restricted from accessing API route endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->